### PR TITLE
fix: renombrar función PATCH para evitar conflicto con PUT y unificar

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,8 +5,10 @@ from controllers.suela_controller import suela_bp
 from controllers.forma_geometrica_controller import forma_bp
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+mysqlconnector://root:1234@localhost:3306/calzado'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config["SQLALCHEMY_DATABASE_URI"] = (
+    "mysql+mysqlconnector://root:admin@localhost:3306/huellasdb"
+)
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 db.init_app(app)
 
@@ -15,7 +17,7 @@ app.register_blueprint(suela_bp)
 app.register_blueprint(forma_bp)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     with app.app_context():
         db.create_all()
-    app.run(host='0.0.0.0', debug=True)
+    app.run(host="0.0.0.0", debug=True)

--- a/src/controllers/forma_geometrica_controller.py
+++ b/src/controllers/forma_geometrica_controller.py
@@ -27,8 +27,9 @@ def create_forma():
         201,
     )
 
+
 @forma_bp.route("/formas/<int:id_forma>", methods=["PATCH"])
-def update_forma(id_forma):
+def patch_forma(id_forma):
     forma = FormaGeometrica.query.get_or_404(id_forma)
     data = request.get_json()
     nombre = data.get("nombre")
@@ -44,10 +45,13 @@ def update_forma(id_forma):
         201,
     )
 
+
 @forma_bp.route("/formas/<int:id_forma>", methods=["GET"])
 def get_forma_by_id(id_forma):
     forma = FormaGeometrica.query.get_or_404(id_forma)
     return jsonify({"id_forma": forma.id_forma, "nombre": forma.nombre})
+
+
 # Endpoint para actualizar una forma geometrica existente por su ID
 @forma_bp.route("/<int:id_forma>", methods=["PUT"])
 def update_forma(id_forma):
@@ -64,33 +68,60 @@ def update_forma(id_forma):
 
         # Si no se reciben datos JSON, devuelve un error 400
         if not data:
-            return jsonify({"message": "No se recibieron datos JSON para la actualización"}), 400
+            return (
+                jsonify(
+                    {"message": "No se recibieron datos JSON para la actualización"}
+                ),
+                400,
+            )
 
         # Actualiza los campos de la forma con los datos recibidos
         # Solo el nombre por ahora, ya que es el unico campo modificable
         if "nombre" in data:
-            #Verificar si el nuevo nombre ya existe
+            # Verificar si el nuevo nombre ya existe
             existing_forma_with_name = FormaGeometrica.query.filter(
                 FormaGeometrica.nombre == data["nombre"],
-                FormaGeometrica.id_forma != id_forma
+                FormaGeometrica.id_forma != id_forma,
             ).first()
             if existing_forma_with_name:
-                return jsonify({"message": f"Ya existe otra forma geométrica con el nombre '{data['nombre']}'."}), 409 # Conflict
+                return (
+                    jsonify(
+                        {
+                            "message": f"Ya existe otra forma geométrica con el nombre '{data['nombre']}'."
+                        }
+                    ),
+                    409,
+                )  # Conflict
 
             forma.nombre = data["nombre"]
         else:
-            return jsonify({"message": "El campo 'nombre' es requerido para la actualizacion"}), 400
+            return (
+                jsonify(
+                    {"message": "El campo 'nombre' es requerido para la actualizacion"}
+                ),
+                400,
+            )
 
         # Confirmar los cambios en la base de datos
         db.session.commit()
 
         # Devuelve la forma actualizada usando to_dict() y un estado 200 OK
-        return jsonify({
-            "message": "Forma geometrica actualizada exitosamente",
-            "forma": forma.to_dict()
-        }), 200
+        return (
+            jsonify(
+                {
+                    "message": "Forma geometrica actualizada exitosamente",
+                    "forma": forma.to_dict(),
+                }
+            ),
+            200,
+        )
 
     except Exception as e:
         # En caso de error, deshacer la transaccion y devolver un error 500
         db.session.rollback()
-        return jsonify({"message": "Error al actualizar la forma geometrica", "error": str(e)}), 500
+        return (
+            jsonify(
+                {"message": "Error al actualizar la forma geometrica", "error": str(e)}
+            ),
+            500,
+        )


### PR DESCRIPTION
rutas

- Cambiada función update_forma en PATCH a patch_forma para evitar error de funciones duplicadas.
  - Todas las rutas de forma usan ahora /formas/<int:id_forma> para mantener consistencia REST.
    - Corrección evita error de Flask por duplicidad de nombres en los handlers.